### PR TITLE
Bugfix: Fix Start level race condition

### DIFF
--- a/src/actions/game_actions.js
+++ b/src/actions/game_actions.js
@@ -90,12 +90,11 @@ export function submitTrial() {
 }
 
 export function startLevel(levelNumber) {
-    return (dispatch) => {
-        dispatch({
-            type: START_LEVEL,
-            levelNumber: levelNumber,
-        });
-        dispatch(newTrial());
+    return {
+        type: START_LEVEL,
+        levelNumber: levelNumber,
+        operation: createOperationForLevel(levelNumber),
+        startTime: new Date().getTime(),
     }
 }
 

--- a/src/reducers/game_reducer.js
+++ b/src/reducers/game_reducer.js
@@ -81,6 +81,20 @@ function hasExceededMaxSolveTime(trialStartTime, trialSubmitTime, operationMaxSo
     return calculateTotalTrialTime(trialStartTime, trialSubmitTime) > operationMaxSolveTime;
 }
 
+function newTrialData(trials, levelNumber, operation, startTime) {
+    return {
+        trialNumber: getNewTrialNumber(trials),
+        levelNumber: levelNumber,
+        currentUserInput: null,
+        operation: operation,
+        startTime: startTime,
+        keysPressed: [],
+        responseTimes: [],
+        hasErased: false,
+        timeExceeded: false,
+    }
+}
+
 export function gameReducer(state = initialState, action) {
     switch (action.type) {
         case START_GAME:
@@ -95,17 +109,8 @@ export function gameReducer(state = initialState, action) {
         case NEW_TRIAL:
             return {
                 ...state,
-                currentTrial: {
-                    trialNumber: getNewTrialNumber(state.currentLevel.trials),
-                    levelNumber: state.currentLevel.number,
-                    currentUserInput: null,
-                    operation: action.operation,
-                    startTime: action.startTime,
-                    keysPressed: [],
-                    responseTimes: [],
-                    hasErased: false,
-                    timeExceeded: false,
-                }
+                currentTrial: newTrialData(state.currentLevel.trials, state.currentLevel.number,
+                    action.operation, action.startTime)
             };
 
         case CALCULATOR_TYPE_INPUT:
@@ -143,7 +148,8 @@ export function gameReducer(state = initialState, action) {
                     totalTrialsTime: 0,
                     efficacy: calculateEfficacy(state.totalCorrect, state.totalTrials),
                 },
-                currentTrial: undefined,
+                currentTrial: newTrialData([], action.levelNumber,
+                    action.operation, action.startTime)
             };
 
         case SUBMIT_TRIAL:


### PR DESCRIPTION
Al hacer los tests, habia algunos que fallaban y descubrí este bug :)

Es una condición de carrera que al usar la app manualmente no lo logro reproducir, pero viendo el código te podes dar cuenta que existe.

Básicamente, al enviarse la acción startLevel() se hacian 2 dispatch, uno despues del otro. El primero dejaba la app en un estado inválido, porque seteaba el status a PLAYING pero sin ningún trial definido. Luego el segundo dispatch era newTrial() que define currentTrial. El tema es que entre una acción y la otra, se renderea el Game que necesita que el currentTrial esté definido.

Hice que todo esto sea atómico para que no pase más esto.

Avisame y si no se entiende nada lo charlamos :p