### PR TITLE
Quito usos de Content y Header de NativeBase que pueden ser problemáticos

### DIFF
--- a/src/components/LoadingAppScreen.js
+++ b/src/components/LoadingAppScreen.js
@@ -12,11 +12,6 @@ import SplashScreen from 'react-native-splash-screen'
 StatusBar.setHidden(true);
 
 export class LoadingAppScreen extends React.Component {
-    static navigationOptions = {
-        title: 'LoadingAppScreen',
-        header: null
-    };
-
     componentDidMount() {
         SplashScreen.hide();
 

--- a/src/components/common/Header.js
+++ b/src/components/common/Header.js
@@ -1,11 +1,10 @@
 import React, {Component} from "react";
-import {View, Text} from "react-native";
+import {Text, View} from "react-native";
 import {BackButton} from "./BackButton";
-import {Header} from "native-base";
 import {HEADER_STYLES} from "../../styles/common/styles";
 import {withNavigation} from "react-navigation";
 
-export const MoravecHeader = withNavigation(class extends React.Component {
+export const MoravecHeader = withNavigation(class extends Component {
     constructor(props) {
         super(props);
         this.handleGoBack = this.handleGoBack.bind(this);
@@ -17,14 +16,14 @@ export const MoravecHeader = withNavigation(class extends React.Component {
 
     render() {
         return (
-            <Header style={HEADER_STYLES.header}>
+            <View style={HEADER_STYLES.header}>
                 <View style={HEADER_STYLES.left}>
                     <BackButton goBack={this.handleGoBack}/>
                 </View>
                 <View style={HEADER_STYLES.titleContent}>
                     <Text style={HEADER_STYLES.title}>{this.props.title}</Text>
                 </View>
-            </Header>
+            </View>
         )
     }
 });

--- a/src/components/home/Home.js
+++ b/src/components/home/Home.js
@@ -10,8 +10,6 @@ import {TouchableWithoutFeedback} from "react-native";
 
 export class Home extends React.Component {
     static navigationOptions = {
-        title: 'Home',
-        header: null,
         gesturesEnabled: false,
     };
 

--- a/src/components/level_selection/LevelSelection.js
+++ b/src/components/level_selection/LevelSelection.js
@@ -1,6 +1,6 @@
 import React from "react";
-import {View} from "react-native";
-import {Content, Spinner} from "native-base";
+import {ScrollView, View} from "react-native";
+import {Spinner} from "native-base";
 import {LEVEL_SELECTION_STYLES} from "../../styles/game/styles"
 import {spinnerColor} from "../../styles/main/styles";
 import I18n from "../../../i18n/i18n";
@@ -61,7 +61,7 @@ export let LevelSelection = class extends React.Component {
             if (Config.UNLOCK_ALL_LEVELS === 'on') {
                 const allLevels = Array.from(Array(this.props.numLevels), (_, x) => x + 1);
                 return (
-                    <View style={LEVEL_SELECTION_STYLES.list}>
+                    <ScrollView style={LEVEL_SELECTION_STYLES.list}>
                         {allLevels.map((levelNumber) => (
                             <PlayLevelButton key={levelNumber} levelCompleted={true}
                                              onPress={() => this.handleLevelSelected(parseInt(levelNumber))}
@@ -69,14 +69,14 @@ export let LevelSelection = class extends React.Component {
                                              stars={0}
                             />
                         ))}
-                    </View>
+                    </ScrollView>
                 )
             } else {
                 return (
-                    <View style={LEVEL_SELECTION_STYLES.list}>
+                    <ScrollView style={LEVEL_SELECTION_STYLES.list}>
                         {this.renderPreviouslyCompletedLevels()}
                         {this.renderNewLevelToPlay()}
-                    </View>
+                    </ScrollView>
                 )
             }
         }
@@ -84,10 +84,10 @@ export let LevelSelection = class extends React.Component {
 
     render() {
         return (
-            <Content>
+            <View>
                 <MoravecHeader title={I18n.t('game.headerTitle').toUpperCase()}/>
                 {this.renderLevelsList()}
-            </Content>
+            </View>
         )
     }
 };

--- a/src/components/practice/PracticeModeSelection.js
+++ b/src/components/practice/PracticeModeSelection.js
@@ -1,20 +1,14 @@
 import React from "react";
-import {View} from "react-native";
-import {Content} from "native-base";
+import {ScrollView, View} from "react-native";
 import {PracticeModeOption} from "./PracticeModeOption";
 import I18n from "../../../i18n/i18n";
 import {PRACTICE_MODE_SELECTION_STYLES} from "../../styles/practice/styles";
 import {makeItTestable} from "../../utils/testable_hoc";
 import {MoravecHeader} from "../common/Header";
-import {INITIAL, ADVANCED, INTERMEDIATE} from "../../models/practice/PracticeMode";
+import {ADVANCED, INITIAL, INTERMEDIATE} from "../../models/practice/PracticeMode";
 import {OperationCategory} from "../../models/operations/Category";
 
 export let PracticeModeSelection = class extends React.Component {
-    static navigationOptions = {
-        title: 'Practice',
-        header: null
-    };
-
     constructor(props) {
         super(props);
         this.handlePracticeModeSelected = this.handlePracticeModeSelected.bind(this);
@@ -26,9 +20,10 @@ export let PracticeModeSelection = class extends React.Component {
 
     render() {
         return (
-            <Content>
+            <View>
                 <MoravecHeader title={I18n.t('practice.headerTitle').toUpperCase()}/>
-                <View style={PRACTICE_MODE_SELECTION_STYLES.container}>
+                <ScrollView contentContainerStyle={PRACTICE_MODE_SELECTION_STYLES.container}
+                            style={PRACTICE_MODE_SELECTION_STYLES.content}>
                     <View style={PRACTICE_MODE_SELECTION_STYLES.row}>
                         <PracticeModeOption category={new OperationCategory("1d+1d")} difficulty={INITIAL}
                                             handleSelect={this.handlePracticeModeSelected}/>
@@ -85,8 +80,8 @@ export let PracticeModeSelection = class extends React.Component {
                         <PracticeModeOption category={new OperationCategory("(4d)^2")} difficulty={ADVANCED}
                                             handleSelect={this.handlePracticeModeSelected}/>
                     </View>
-                </View>
-            </Content>
+                </ScrollView>
+            </View>
         )
     }
 };

--- a/src/components/statistics/OperationStatsScreen.js
+++ b/src/components/statistics/OperationStatsScreen.js
@@ -1,17 +1,14 @@
 import React from "react";
 import {Text, View} from "react-native";
-import {Content} from "native-base";
 import {makeItTestable} from "../../utils/testable_hoc";
 import {MoravecHeader} from "../common/Header";
 import I18n from "../../../i18n/i18n";
-import {VictoryChart, VictoryLine, VictoryScatter, VictoryAxis} from "victory-native";
+import {VictoryAxis, VictoryChart, VictoryLine, VictoryScatter} from "victory-native";
 import {applyLetterSpacing} from "../../styles/global";
 import {CHART_STYLES} from "../../styles/stats/styles";
 import {OperationCategory} from "../../models/operations/Category";
 
 export let OperationStatsScreen = class extends React.Component {
-    static navigationOptions = {header: null};
-
     constructor(props) {
         super(props);
     }
@@ -37,7 +34,7 @@ export let OperationStatsScreen = class extends React.Component {
 
     render() {
         return (
-            <Content style={CHART_STYLES.content}>
+            <View style={CHART_STYLES.content}>
                 <MoravecHeader title={I18n.t('stats.headerTitle').toUpperCase()}/>
                 <View style={CHART_STYLES.container}>
                     <View style={CHART_STYLES.categoryNameContainer}>
@@ -61,7 +58,7 @@ export let OperationStatsScreen = class extends React.Component {
                 <View style={CHART_STYLES.horizontalLabelContainer}>
                     <Text style={CHART_STYLES.horizontalLabel}>{I18n.t('stats.chart.horizontalAxisLabel')}</Text>
                 </View>
-            </Content>
+            </View>
         )
     }
 };

--- a/src/components/statistics/StatsMainScreen.js
+++ b/src/components/statistics/StatsMainScreen.js
@@ -1,6 +1,6 @@
 import React from "react";
 import {Text, View} from "react-native";
-import {Content, Spinner} from "native-base";
+import {Spinner} from "native-base";
 import {makeItTestable} from "../../utils/testable_hoc";
 import {MoravecHeader} from "../common/Header";
 import I18n from "../../../i18n/i18n";
@@ -36,21 +36,15 @@ export let StatsMainScreen = class extends React.Component {
             return (
                 <View>
                     <View style={CATEGORIES_LIST_STYLES.header}>
-                        <View style={CATEGORIES_LIST_STYLES.leftTextHeaderContainer}>
-                            <Text key={0} style={CATEGORIES_LIST_STYLES.leftTextHeader}>
-                                {I18n.t('stats.statsSelection.header.category')}
-                            </Text>
-                        </View>
-                        <View style={CATEGORIES_LIST_STYLES.centerTextHeaderContainer}>
-                            <Text key={1} style={CATEGORIES_LIST_STYLES.centerTextHeader}>
-                                {I18n.t('stats.statsSelection.header.averageTime')}
-                            </Text>
-                        </View>
-                        <View style={CATEGORIES_LIST_STYLES.rightTextHeaderContainer}>
-                            <Text key={2} style={CATEGORIES_LIST_STYLES.rightTextHeader}>
-                                {I18n.t('stats.statsSelection.header.effectiveness')}
-                            </Text>
-                        </View>
+                        <Text key={0} style={CATEGORIES_LIST_STYLES.textHeader}>
+                            {I18n.t('stats.statsSelection.header.category')}
+                        </Text>
+                        <Text key={1} style={CATEGORIES_LIST_STYLES.textHeader}>
+                            {I18n.t('stats.statsSelection.header.averageTime')}
+                        </Text>
+                        <Text key={2} style={CATEGORIES_LIST_STYLES.textHeader}>
+                            {I18n.t('stats.statsSelection.header.effectiveness')}
+                        </Text>
                     </View>
                     <View style={CATEGORIES_LIST_STYLES.list}>
                         {this.renderOperationsStats()}
@@ -64,10 +58,10 @@ export let StatsMainScreen = class extends React.Component {
 
     render() {
         return (
-            <Content>
+            <View>
                 <MoravecHeader title={I18n.t('stats.headerTitle').toUpperCase()}/>
                 {this.renderContent()}
-            </Content>
+            </View>
         )
     }
 };

--- a/src/components/tutorials/TutorialsList.js
+++ b/src/components/tutorials/TutorialsList.js
@@ -1,20 +1,15 @@
 import React from "react";
-import {Text, View, TouchableOpacity} from "react-native";
-import {Content, Icon} from "native-base";
+import {Text, TouchableOpacity, View} from "react-native";
+import {Icon} from "native-base";
 import {MoravecHeader} from "../common/Header";
 import I18n from "../../../i18n/i18n";
 import {LIST_STYLES} from "../../styles/tutorials/styles";
 
 export class TutorialsList extends React.Component {
-    static navigationOptions = {
-        title: 'Tutoriales',
-        header: null
-    };
-
     render() {
         const {navigate} = this.props.navigation;
         return (
-            <Content>
+            <View>
                 <MoravecHeader title='TUTORIAL'/>
                 <View style={LIST_STYLES.list}>
                     <TouchableOpacity style={LIST_STYLES.item} onPress={() => navigate('ViewAdditionTutorial')}>
@@ -44,7 +39,7 @@ export class TutorialsList extends React.Component {
                         <Icon style={LIST_STYLES.icon} name="ios-arrow-forward"/>
                     </TouchableOpacity>
                 </View>
-            </Content>
+            </View>
         );
     }
 }

--- a/src/components/tutorials/ViewAdditionTutorial.js
+++ b/src/components/tutorials/ViewAdditionTutorial.js
@@ -6,11 +6,6 @@ import Images from "../../../assets/images/images";
 import {TUTORIAL_STYLES} from "../../styles/tutorials/styles";
 
 export class ViewAdditionTutorial extends React.Component {
-    static navigationOptions = {
-        title: 'Tutorial',
-        header: null
-    };
-
     videoId() {
         if (I18n.currentLocale().startsWith('es')) {
             return "Ies8X7VxGKs";

--- a/src/components/tutorials/ViewMajorSystemTutorial.js
+++ b/src/components/tutorials/ViewMajorSystemTutorial.js
@@ -6,11 +6,6 @@ import Images from "../../../assets/images/images";
 import {TUTORIAL_STYLES} from "../../styles/tutorials/styles";
 
 export class ViewMajorSystemTutorial extends React.Component {
-    static navigationOptions = {
-        title: 'Tutorial',
-        header: null
-    };
-
     videoId() {
         if (I18n.currentLocale().startsWith('es')) {
             return "Fv0Si7UJHKw";

--- a/src/components/tutorials/ViewMutiplicationTutorial.js
+++ b/src/components/tutorials/ViewMutiplicationTutorial.js
@@ -6,11 +6,6 @@ import Images from "../../../assets/images/images";
 import {TUTORIAL_STYLES} from "../../styles/tutorials/styles";
 
 export class ViewMultiplicationTutorial extends React.Component {
-    static navigationOptions = {
-        title: 'Tutorial',
-        header: null
-    };
-
     videoId() {
         if (I18n.currentLocale().startsWith('es')) {
             return "mwa-zblNdR4";

--- a/src/components/tutorials/ViewToSquare2Tutorial.js
+++ b/src/components/tutorials/ViewToSquare2Tutorial.js
@@ -6,11 +6,6 @@ import Images from "../../../assets/images/images";
 import {TUTORIAL_STYLES} from "../../styles/tutorials/styles";
 
 export class ViewToSquare2Tutorial extends React.Component {
-    static navigationOptions = {
-        title: 'Tutorial',
-        header: null
-    };
-
     videoId() {
         if (I18n.currentLocale().startsWith('es')) {
             return "_CUWlWjFreM";

--- a/src/components/tutorials/ViewToSquare3Tutorial.js
+++ b/src/components/tutorials/ViewToSquare3Tutorial.js
@@ -6,11 +6,6 @@ import I18n from "../../../i18n/i18n";
 import {TUTORIAL_STYLES} from "../../styles/tutorials/styles";
 
 export class ViewToSquare3Tutorial extends React.Component {
-    static navigationOptions = {
-        title: 'Tutorial',
-        header: null
-    };
-
     videoId() {
         if (I18n.currentLocale().startsWith('es')) {
             return "VHsTlMzN76g";

--- a/src/components/tutorials/ViewToSquare4Tutorial.js
+++ b/src/components/tutorials/ViewToSquare4Tutorial.js
@@ -6,11 +6,6 @@ import I18n from "../../../i18n/i18n";
 import {TUTORIAL_STYLES} from "../../styles/tutorials/styles";
 
 export class ViewToSquare4Tutorial extends React.Component {
-    static navigationOptions = {
-        title: 'Tutorial',
-        header: null
-    };
-
     videoId() {
         if (I18n.currentLocale().startsWith('es')) {
             return "WW_VLPJ__V0";

--- a/src/containers/GameEngine.js
+++ b/src/containers/GameEngine.js
@@ -51,11 +51,6 @@ const mapDispatchToProps = dispatch => {
 };
 
 class GameEngine extends Component {
-    static navigationOptions = {
-        title: 'Game',
-        header: null
-    };
-
     constructor(props) {
         super(props);
 

--- a/src/containers/LevelSelectionContainer.js
+++ b/src/containers/LevelSelectionContainer.js
@@ -24,11 +24,6 @@ const mapDispatchToProps = dispatch => {
 };
 
 class LevelSelectionContainer extends Component {
-    static navigationOptions = {
-        title: 'Levels',
-        header: null
-    };
-
     constructor(props) {
         super(props);
 

--- a/src/containers/PersonalInfo.js
+++ b/src/containers/PersonalInfo.js
@@ -24,12 +24,6 @@ const mapDispatchToProps = dispatch => {
 };
 
 class PersonalInfo extends Component {
-    static navigationOptions = {
-        title: 'PersonalInfo',
-        header: null,
-        gesturesEnabled: false,
-    };
-
     constructor(props) {
         super(props);
 

--- a/src/containers/Practice.js
+++ b/src/containers/Practice.js
@@ -44,11 +44,6 @@ const mapDispatchToProps = dispatch => {
 };
 
 class Practice extends Component {
-    static navigationOptions = {
-        title: 'Practice',
-        header: null
-    };
-
     constructor(props) {
         super(props);
         this.handleSubmit = this.handleSubmit.bind(this);

--- a/src/containers/StatsContainer.js
+++ b/src/containers/StatsContainer.js
@@ -4,8 +4,6 @@ import {StatsMainScreen} from "../components/statistics/StatsMainScreen";
 import {fetchOperationCategoryStats} from "../actions/stats_actions";
 
 class StatsContainer extends React.Component {
-    static navigationOptions = {header: null};
-
     constructor(props) {
         super(props);
         this.handleShowOperationStats = this.handleShowOperationStats.bind(this);

--- a/src/navigator.js
+++ b/src/navigator.js
@@ -23,6 +23,10 @@ export const PersonalInfoStack = createStackNavigator(
     },
     {
         initialRouteName: 'PersonalInfoContainer',
+        navigationOptions: {
+            gesturesEnabled: false,
+            header: null
+        }
     }
 );
 
@@ -48,8 +52,9 @@ export const HomeStack = createStackNavigator(
         headerMode: 'screen',
         navigationOptions: {
             gestureResponseDistance: {
-                horizontal: 150
-            }
+                horizontal: 150,
+            },
+            header: null
         }
     }
 );
@@ -62,5 +67,8 @@ export const Navigator = createSwitchNavigator(
     },
     {
         initialRouteName: 'LoadingAppScreen',
+        navigationOptions: {
+            header: null
+        }
     }
 );

--- a/src/styles/common/styles.js
+++ b/src/styles/common/styles.js
@@ -23,7 +23,6 @@ export const HEADER_STYLES = {
         backgroundColor: lightGrayColor,
         height: getWindowHeight() * 0.1,
         elevation: 0,
-        flex: 2,
         flexDirection: "row",
         justifyContent: "flex-start",
         alignItems: "center"

--- a/src/styles/game/styles.js
+++ b/src/styles/game/styles.js
@@ -162,8 +162,8 @@ export const LEVEL_FINISHED_STYLES = {
 
 export const LEVEL_SELECTION_STYLES = {
     list: {
-        flex: 1,
         backgroundColor: lightGrayColor,
+        height: getWindowHeight() * 0.85,
     },
     alreadyPlayedItem: {
         backgroundColor: whiteColor,
@@ -178,7 +178,7 @@ export const LEVEL_SELECTION_STYLES = {
         borderBottomColor: superLightGrayColor,
     },
     listItemContainer: {
-        flex: 2,
+        flex: 1,
         flexDirection: "row",
         justifyContent: 'space-between',
         alignItems: "center",

--- a/src/styles/practice/styles.js
+++ b/src/styles/practice/styles.js
@@ -13,9 +13,10 @@ const windowHeight = getWindowHeight();
 const windowWidth = getWindowWidth();
 
 export const PRACTICE_MODE_SELECTION_STYLES = {
+    content: {
+        height: getWindowHeight() * 0.85,
+    },
     container: {
-        flex: 7,
-        flexDirection: 'column',
         justifyContent: 'space-between',
         backgroundColor: lightGrayColor,
         borderStyle: 'solid',
@@ -25,7 +26,6 @@ export const PRACTICE_MODE_SELECTION_STYLES = {
         borderRightColor: superLightGrayColor,
     },
     row: {
-        flex: 3,
         flexDirection: 'row',
         justifyContent: 'space-between',
     },

--- a/src/styles/stats/styles.js
+++ b/src/styles/stats/styles.js
@@ -6,7 +6,6 @@ const windowWidth = getWindowWidth();
 
 export const CATEGORIES_LIST_STYLES = {
     header: {
-        flex: 3,
         flexDirection: "row",
         backgroundColor: whiteColor,
         justifyContent: "space-around",
@@ -15,43 +14,15 @@ export const CATEGORIES_LIST_STYLES = {
         height: 30,
         alignItems: "center"
     },
-    leftTextHeaderContainer: {
-        flex: 1,
-        alignContent: "flex-start",
-        flexGrow: 1,
-        paddingLeft: 10
-    },
-    leftTextHeader: {
-        fontSize: 15,
-        color: grayColor,
-        fontFamily: "GothamBook",
-    },
-    centerTextHeaderContainer: {
-        flex: 1,
-        alignContent: "flex-start",
-        flexGrow: 1.5
-    },
-    centerTextHeader: {
-        fontSize: 15,
-        color: grayColor,
-        fontFamily: "GothamBook",
-    },
-    rightTextHeaderContainer: {
-        flex: 1,
-        alignContent: "flex-start",
-        flexGrow: 1
-    },
-    rightTextHeader: {
+    textHeader: {
         fontSize: 15,
         color: grayColor,
         fontFamily: "GothamBook",
     },
     list: {
-        flex: 1,
         backgroundColor: lightGrayColor,
     },
     availableItem: {
-        flex: 3,
         flexDirection: "row",
         justifyContent: "space-around",
         alignItems: "center",
@@ -61,7 +32,6 @@ export const CATEGORIES_LIST_STYLES = {
         borderBottomColor: superLightGrayColor,
     },
     unavailableItem: {
-        flex: 2,
         flexDirection: "row",
         justifyContent: "space-around",
         alignItems: "center",
@@ -124,8 +94,6 @@ export const CHART_STYLES = {
         backgroundColor: whiteColor,
     },
     container: {
-        flex: 2,
-        flexDirection: "column",
         paddingBottom: 60
     },
     categoryNameContainer: {

--- a/src/styles/tutorials/styles.js
+++ b/src/styles/tutorials/styles.js
@@ -71,7 +71,6 @@ export const TUTORIAL_STYLES = {
 
 export const LIST_STYLES = {
     list: {
-        flex: 1,
         backgroundColor: lightGrayColor,
     },
     item: {
@@ -79,7 +78,6 @@ export const LIST_STYLES = {
         height: windowHeight * 0.1,
         borderBottomWidth: 4,
         borderBottomColor: superLightGrayColor,
-        flex: 2,
         flexDirection: "row",
         justifyContent: 'space-between',
         alignItems: "center",


### PR DESCRIPTION
- Uso View en lugar de Header de NativeBase para evitar depender de NativeBase y que la status bar cambie de color (al valor por defecto del tema default de NativeBase).
- Uso View en lugar de Content para evitar usar NativeBase en el layout. Esto hizo que se rompan varios layout que usaban mal flex y hubo que corregirlos.

Además, muevo config de header al Navigator para no tener que repetir en todas las pantallas.

De paso, simplifico estílos de pantalla de Stats.