### PR TITLE
Bugfix: Recargar niveles jugados al volver para atrás.

### DIFF
--- a/src/components/level_selection/LevelSelection.js
+++ b/src/components/level_selection/LevelSelection.js
@@ -8,6 +8,7 @@ import {PlayLevelButton} from "./PlayLevelButton";
 import {makeItTestable} from "../../utils/testable_hoc";
 import {MoravecHeader} from "../common/Header";
 import Config from "react-native-config";
+import {NavigationEvents} from "react-navigation";
 
 export let LevelSelection = class extends React.Component {
     constructor(props) {
@@ -85,6 +86,7 @@ export let LevelSelection = class extends React.Component {
     render() {
         return (
             <View>
+                <NavigationEvents onDidFocus={this.props.onLoading}/>
                 <MoravecHeader title={I18n.t('game.headerTitle').toUpperCase()}/>
                 {this.renderLevelsList()}
             </View>


### PR DESCRIPTION
Escucho el evento 'focus' del navigator que indica que volvió a ganar foco la pantalla, y recargo los niveles jugados en tal caso.