### PR TITLE
Bugfix stats

### DIFF
--- a/src/containers/StatsContainer.js
+++ b/src/containers/StatsContainer.js
@@ -10,8 +10,11 @@ class StatsContainer extends React.Component {
     }
 
     handleShowOperationStats(operationCategoryCodename, responseTimes) {
-        this.props.navigation.navigate('OperationStatsScreen',
-            {categoryCodename: operationCategoryCodename, responseTimes: responseTimes});
+        const atLeastOneDataToShowInTheGraph = responseTimes.length > 0;
+        if (atLeastOneDataToShowInTheGraph) {
+            this.props.navigation.navigate('OperationStatsScreen',
+                {categoryCodename: operationCategoryCodename, responseTimes: responseTimes});
+        }
     }
 
     componentDidMount() {

--- a/src/reducers/stats_reducer.js
+++ b/src/reducers/stats_reducer.js
@@ -9,7 +9,7 @@ function effectiveness(corrrectTrialsTimes, totalTrials) {
 }
 
 function averageTime(trialsTime) {
-    const totalTime = trialsTime.reduce((accumTime, trialTime) => accumTime + trialTime);
+    const totalTime = trialsTime.reduce((accumTime, trialTime) => accumTime + trialTime, 0);
     const totalTrials = trialsTime.length;
 
     return totalTime / totalTrials;
@@ -20,10 +20,10 @@ export function statsReducer(state = initialState, action) {
         case CALCULATE_STATS:
             const stats = action.stats;
             const operationCategoryStats = stats.map((operationStats) => {
-                const totalTrialsForCategory = operationStats.correctTrialsTimes.length +
-                    operationStats.incorrectTrialsTimes.length;
+                const numCorrectTrials = operationStats.correctTrialsTimes.length;
+                const totalTrialsForCategory = numCorrectTrials + operationStats.incorrectTrialsTimes.length;
 
-                if (totalTrialsForCategory > 0) {
+                if (numCorrectTrials > 0) {
                     return {
                         categoryCodename: operationStats.categoryCodename,
                         effectiveness: effectiveness(operationStats.correctTrialsTimes, totalTrialsForCategory),


### PR DESCRIPTION
Prevenir crash cuando no se haya contestando ningún trial correctamente.

Decisión tomada: No mostrar datos hasta que no haya al menos una respuesta correcta.

De todos modos, se previene que se pueda navegar hasta el gráfico si no hay al menos una respuesta correcta, por si se optara por mostrar datos aún sin haber al menos un trial correcto.