### PR TITLE
Fix texto de respuesta correctas en pantalla de nivel superado.

### DIFF
--- a/src/styles/game/styles.js
+++ b/src/styles/game/styles.js
@@ -50,7 +50,7 @@ export const LEVEL_FINISHED_STYLES = {
             marginBottom: windowHeight * 0.01
         },
         results: {
-            fontSize: 20,
+            fontSize: 16,
             color: grayColor,
             fontFamily: "Gotham-Book",
             textAlign: 'center',


### PR DESCRIPTION
En Android se vé cortado, por lo que se achicó la fuente.